### PR TITLE
Changing project name to circleci/mongofinil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mongofinil "0.2.1"
+(defproject circleci/mongofinil "0.2.1"
   :description "A library for Mongoid-like models"
   :dependencies [[org.clojure/clojure "1.4.0"]
 


### PR DESCRIPTION
Self-explanatory; this is so that we can keep track of shenanigans in Clojars, per @arohner 
