### PR TITLE
Rolls back clojure version, fixes tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject mongofinil "0.2.1"
   :description "A library for Mongoid-like models"
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
 
                  ;; DB
                  [congomongo "0.4.1"]

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -179,15 +179,15 @@
                {:doc doc
                 :arglists arglists}) fn))
 
+(defn dot-keyword-to-unnested-vector
+  "Takes a dot-notated keyword and splits it into a vector of keywords"
+  [k]
+  (map keyword (clojure.string/split (name k) #"[\.]")))
+
 (defn convert-dotmap-to-nested
   "Converts a map with dot-notated keys to a nested map"
-  [hm]
-  (reduce-kv (fn [hm k v]
-               (assoc-in hm (map keyword (clojure.string/split (name k) #"[\.]"))
-                         (if (map? v)
-                           (convert-dotmap-to-nested v)
-                           v)))
-             {} hm))
+  [m]
+  (reduce (fn [m [k v]] (assoc-in m (dot-keyword-to-unnested-vector k) v)) {} m))
 
 (defn is-dot-notated?
   "Checks if a keyword is in dot-notation"


### PR DESCRIPTION
In updating the mongofinil Clojure version from 1.3 to 1.4, I broke
existing tests. Since I don't really understand why things broke, I'm
rolling the version back to 1.3 and just re-writing the one function I
had that required a version 1.4 function, which frankly makes this more
readable anyways.
