### PR TITLE
Allow callers to pass middleware to wrap mongofinil fns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It takes some inspiration from Mongoid, from the Rails world, but attempts to be
 ### Installation
 
 ```clojure
-    [mongofinil "0.1.11"]
+    [mongofinil "0.2.17"]
 ```
 
 ### Usage
@@ -49,6 +49,27 @@ Now use it:
 ```
 
 
+#### Middleware
+
+Sometimes you need to perform actions around each call of the functions
+mongofinil creates. This typically crops up if one of your models needs to live
+in a different database to the rest of your models.
+
+You can pass a middleware function as part of your model declaration which will
+be wrapped around each of the mongofinil functions as they are created.
+
+```clojure
+(defn wrap-with-foo-db [f]
+  (fn [& args]
+    (somnium.congomongo/with-mongo foo-db-conn
+      (apply f args))))
+
+(mongofinil/defmodel :admins
+  :fields
+  [{:name :username :finaable true}
+   {:name :emails :default []}]
+  :fn-middleware #'wrap-with-foo-db)
+```
 
 
 #### Notes

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/mongofinil "0.2.16"
+(defproject circleci/mongofinil "0.2.17"
   :description "A library for Mongoid-like models"
   :dependencies [[org.clojure/clojure "1.6.0"]
 

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -519,9 +519,9 @@
                  :keywords keywords
                  :strings strings
                  :name "create!"
-                 :hooks [[:create [:pre]]
-                         [:update [:pre]]
-                         [:load [:post]]]
+                 :hooks {:create [:pre]
+                         :update [:pre]
+                         :load [:post]}
                  :profile profile-writes}
 
         ;;; raw find-and-modify

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -360,11 +360,19 @@
                (#(apply f % opts))
                (call-post-hooks post-hooks returns-list)))))))
 
+(defn wrap-fn-middleware
+  [f middleware]
+  (if (nil? middleware)
+    f
+    (let [handler (middleware f)]
+      (assert (fn? handler) "middleware should return a function")
+        handler)))
+
 (defn add-functions
   "Takes a list of hashes which define functions, wraps those functions
   according to their specification, and interns those functions in the target
   namespace"
-  [ns function-defs model-hooks]
+  [ns function-defs model-hooks fn-middleware]
   (doseq [fdef function-defs]
     (let [{:keys [name fn
                   doc arglists
@@ -402,6 +410,7 @@
           (wrap-unwrap-single-object returns-list)
           (wrap-hooks returns-list (select-keys model-hooks [:ref]) (when output-ref
                                                                       {:ref [:post]}))
+          (wrap-fn-middleware fn-middleware)
           (intern-fn {:ns ns :name name :doc doc :arglists arglists})))))
 
 
@@ -767,7 +776,7 @@
 
 (defn defmodel
   "Define a DB model from its fields"
-  [collection & {:keys [validators fields use-refs profile-reads profile-writes hooks]
+  [collection & {:keys [validators fields use-refs profile-reads profile-writes hooks fn-middleware]
                  :or {validators [] fields [] use-refs false hooks {}}
                  :as attrs}]
   (let [fields (into [] (eager-map canonicalize-field-defs fields))
@@ -777,7 +786,7 @@
         strings (into #{} (eager-map :name (filter :strings fields)))
         row-templates (create-row-functions collection validators fields defaults transients use-refs keywords strings profile-reads profile-writes)
         col-templates (apply concat (for [f fields] (create-col-function collection f defaults transients use-refs keywords strings profile-reads profile-writes)))]
-    (add-functions *ns* (into [] (concat col-templates row-templates)) hooks)))
+    (add-functions *ns* (into [] (concat col-templates row-templates)) hooks fn-middleware)))
 
 
 (defn defapi [&args])


### PR DESCRIPTION
Sometimes you need to perform actions around each call of the functions
mongofinil creates. This typically crops up if one of your models needs to live
in a different database to the rest of your models.

You can pass a middleware function as part of your model declaration which will
be wrapped around each of the mongofinil functions as they are created.

Happy to accept other names for the concept, names are hard.