### PR TITLE
load defaults properly when :only specified as map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/mongofinil "0.2.17"
+(defproject circleci/mongofinil "0.2.18"
   :description "A library for Mongoid-like models"
   :dependencies [[org.clojure/clojure "1.6.0"]
 

--- a/test/mongofinil/test_core.clj
+++ b/test/mongofinil/test_core.clj
@@ -191,6 +191,22 @@
   (find-one-by-x! 22) => (contains {:dx 5 :dy 6 :dz 22})
   (find-one-by-x 22) => (contains {:dx 5 :dy 6 :dz 22}))
 
+(fact "default works on loading with :only specified as a collection."
+      (congo/insert! :xs {:x 22 :y 33 :z 44})
+      (find-one-by-x! 22 :only [:x :y :def1]) => (contains {:def1 5}))
+
+(fact "default works on loading with :only specified as a map."
+      (congo/insert! :xs {:x 22 :y 33 :z 44})
+      (find-one-by-x! 22 :only {:x true :y true :def1 true}) => (contains {:def1 5}))
+
+(fact "default works on loading with :only specified as a map with false values."
+      (congo/insert! :xs {:x 22 :y 33 :z 44})
+      (find-one-by-x! 22 :only {:x false}) => (contains {:def1 5}))
+
+(fact "default works on loading with :only specified as a map and :_id specified"
+      (congo/insert! :xs {:x 22 :y 33 :z 44})
+      (find-one-by-x! 22 :only {:x true :def1 true :_id false}) => (contains {:def1 5}))
+
 (fact "defaults work in order"
   (create! {:x 11}) => (contains {:x 11 :def1 5 :def2 6 :def3 7 :def4 11}))
 


### PR DESCRIPTION
This change is needed for default values to properly populate for code that passes a map to :only , e.g. https://github.com/circleci/circle/blob/269b5a8/src/circle/http/api.clj#L110 .

