### PR TITLE
Upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ workflows:
   test:
     jobs:
       - midje-with-mongo/test:
-          name: "test-mongo-2.4.10"
-          mongo-version: "2.4.10"
-      - midje-with-mongo/test:
           name: "test-mongo-2.6.9"
           mongo-version: "2.6.9"
       - midje-with-mongo/test:

--- a/project.clj
+++ b/project.clj
@@ -1,32 +1,10 @@
 (defproject circleci/mongofinil "0.2.20"
   :description "A library for Mongoid-like models"
-  :dependencies [[org.clojure/clojure "1.6.0"]
-
-                 ;; DB
-                 [circleci/congomongo "0.4.5-58d755baa9dc5daeab67516058ccd2a590766a2f"]
-
-                 ;; Misc
-                 [clj-time "0.9.0"]
-                 [org.clojure/tools.logging "0.2.3"]
-
-                 [bultitude "0.1.7"]
-                 [lein-midje "3.0.1"]
-                 [midje "1.5.1"]]
-
-  :dev-dependencies [[lein-test-out "0.1.1"]
-                     [midje "1.5.1" :exclusions [org.clojure/clojure]]
-                     [bultitude "0.1.7"]
-                     [lein-midje "3.0.1"]
-                     [bond "0.2.6" :exclusions [org.clojure/clojure]]
-                     [clojure-source "1.2.1"]]
-  :profiles {:dev
-             {:dependencies
-              [[lein-test-out "0.1.1"]
-               [midje "1.5.1" :exclusions [org.clojure/clojure]]
-               [bultitude "0.1.7"]
-               [lein-midje "3.0.1"]
-               [bond "0.2.6" :exclusions [org.clojure/clojure]]]}}
-
-  :plugins [[lein-midje "3.0.1"]]
-
-  :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}})
+  :dependencies [[congomongo "1.1.0"]
+                 [clj-time "0.14.0"]
+                 [org.clojure/tools.logging "0.4.1"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [circleci/bond "0.3.1"]
+                                  [midje "1.9.9" :exclusions [clj-time
+                                                              org.clojure/clojure]]]}}
+  :plugins [[lein-midje "3.2.1"]])

--- a/test/mongofinil/test_core.clj
+++ b/test/mongofinil/test_core.clj
@@ -4,8 +4,7 @@
             [somnium.congomongo :as congo]
             [mongofinil.core :as core]
             [mongofinil.testing-utils :as utils])
-  (:use midje.sweet
-        [clojure.core.incubator :only (-?>)])
+  (:use midje.sweet)
   (:import org.bson.types.ObjectId))
 
 (defn initializer []

--- a/test/mongofinil/test_hooks.clj
+++ b/test/mongofinil/test_hooks.clj
@@ -3,8 +3,7 @@
             [somnium.congomongo :as congo]
             [mongofinil.core :as core]
             [mongofinil.testing-utils :as utils])
-  (:use midje.sweet
-        [clojure.core.incubator :only (-?>)])
+  (:use midje.sweet)
   (:import org.bson.types.ObjectId))
 
 


### PR DESCRIPTION
- Upgrade congomongo from the CircleCI patched version to the mainline version 1.1.0
- Upgrade clj-time to 0.14.0
- Upgrade org.clojure/tools.logging to 0.4.1
- Clean up project.clj so that only true dependencies are in the dependencies vector. Everything else is brought in from the dev profile.