### PR TITLE
Clean up the codebase a little

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,7 @@
 (defproject circleci/mongofinil "0.2.20"
   :description "A library for Mongoid-like models"
   :dependencies [[congomongo "1.1.0"]
-                 [clj-time "0.14.0"]
-                 [org.clojure/tools.logging "0.4.1"]]
+                 [clj-time "0.14.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [circleci/bond "0.3.1"]
                                   [midje "1.9.9" :exclusions [clj-time

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -1,13 +1,14 @@
 (ns mongofinil.core
   "A Mongoid-like library that lets you focus on the important stuff"
-  (:require [somnium.congomongo :as congo]
-            [somnium.congomongo.coerce :as congo-coerce :refer [*translations*]]
-            [mongofinil.validation :as mv]
-            [mongofinil.validation-helpers :as mvh]
-            [clj-time.core :as time]
-            [clojure.string :as str])
+  (:require [clojure.string :as str]
 
-  (:use [mongofinil.helpers :only (assert! throw-if-not throw-if ref? throwf eager-map)])
+            [clj-time.core :as time]
+            [somnium.congomongo :as congo]
+            [somnium.congomongo.coerce :as congo-coerce :refer [*translations*]]
+
+            [mongofinil.helpers :refer (assert! eager-map ref? throw-if throw-if-not throwf)]
+            [mongofinil.validation :as mv]
+            [mongofinil.validation-helpers :as mvh])
   (:import org.bson.types.ObjectId
            (org.joda.time DateTime
                           DateTimeZone)))
@@ -241,7 +242,7 @@ note:
    (ref? id) (coerce-id @id)
    (instance? String id) (do (throw-if (= id "") "Got empty string (\"\"), expected id")
                              (congo/object-id id))
-   (instance? org.bson.types.ObjectId id) id
+   (instance? ObjectId id) id
    (:_id id)  (:_id id)
    :else (throwf "Expected id, got %s" id)))
 

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -382,8 +382,9 @@ note:
     (call-post-hooks-plural hooks rows)
     (call-post-hooks-singular hooks rows)))
 
-(defn wrap-hooks [f returns-list model-hooks fn-hooks]
+(defn wrap-hooks
   "Calls the appropriate hooks. model-hooks is the hooks defined in the defmodel. fn-hooks is the hooks on the fn definition."
+  [f returns-list model-hooks fn-hooks]
   (let [pre-hooks (get-hooks :pre model-hooks fn-hooks)
         post-hooks (get-hooks :post model-hooks fn-hooks)]
     (fn [& args]

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -824,6 +824,3 @@ note:
         row-templates (create-row-functions collection validators fields defaults transients use-refs keywords strings profile-reads profile-writes)
         col-templates (apply concat (for [f fields] (create-col-function collection f defaults transients use-refs keywords strings profile-reads profile-writes)))]
     (add-functions *ns* (into [] (concat col-templates row-templates)) hooks fn-middleware metrics-fn)))
-
-
-(defn defapi [&args])

--- a/src/mongofinil/core.clj
+++ b/src/mongofinil/core.clj
@@ -355,7 +355,7 @@ note:
 
 (defn get-hooks [desired-phase model-hooks fn-hooks]
   (->> fn-hooks
-       (map (fn [[crud [& phases]]]
+       (map (fn [[crud [& _phases]]]
               (get-in model-hooks [crud desired-phase])))
        (filter identity)))
 

--- a/src/mongofinil/helpers.clj
+++ b/src/mongofinil/helpers.clj
@@ -69,7 +69,7 @@
 
 (defn ensure-object-id
   "Adds a mongo id to m, a clojure map, if it doesn't have one."
-  [coll m]
+  [_coll m]
   {:post [(identity %)]}
   (if (not (has-object-id? m))
     (assoc m :_id (object-id))

--- a/src/mongofinil/helpers.clj
+++ b/src/mongofinil/helpers.clj
@@ -1,5 +1,4 @@
 (ns mongofinil.helpers
-  (:use [clojure.tools.logging :only (infof)])
   (:import org.bson.types.ObjectId))
 
 (defn ref?
@@ -82,12 +81,3 @@
   (dosync
    (when (not (has-object-id? @m))
      (alter m (constantly (ensure-object-id coll @m))))))
-
-;; (defmacro inspect
-;;   "prints the expression '<name> is <value>', and returns the value"
-;;   [value]
-;;   `(let [value# (quote ~value)
-;;          result# ~value]
-;;      (println value# "is" (with-out-str (clojure.pprint/pprint result#)))
-;;      (infof "%s is %s" value# result#)
-;;      result#))

--- a/src/mongofinil/validation.clj
+++ b/src/mongofinil/validation.clj
@@ -1,5 +1,5 @@
 (ns mongofinil.validation
-  (:use [mongofinil.helpers :only (throw-if-not seq1)]))
+  (:require [mongofinil.helpers :refer (throw-if-not seq1)]))
 
 (defn validate
   "validates an object. validation-seq is a seq of fns. Each fn takes one argument, the object to be validated, and returns nil on success, or a string containing a helpful error message on failure.

--- a/src/mongofinil/validation.clj
+++ b/src/mongofinil/validation.clj
@@ -10,10 +10,9 @@
   [validation-seq obj]
   (->>
    (for [v-fn (seq1 validation-seq)]
-     (do
-       (let [resp (v-fn obj)]
-         (throw-if-not (or (nil? resp) (string? resp)) "Validation fn %s, expected nil or string?, got %s" v-fn (class resp))
-         resp)))
+     (let [resp (v-fn obj)]
+       (throw-if-not (or (nil? resp) (string? resp)) "Validation fn %s, expected nil or string?, got %s" v-fn (class resp))
+       resp))
    (filter identity)
    (first)))
 

--- a/src/mongofinil/validation_helpers.clj
+++ b/src/mongofinil/validation_helpers.clj
@@ -58,8 +58,7 @@
   "Takes a map of keys to classes. Validates that each key in map is of the specified class."
   [ks]
   (fn [o]
-    (map-predicate (fn [field cls]
-                     (key-type o field cls)) ks)))
+    (map-predicate #((key-type %1 %2) o) ks)))
 
 (defn is-map? [& [msg]]
   (require-predicate map? msg))

--- a/src/mongofinil/validation_helpers.clj
+++ b/src/mongofinil/validation_helpers.clj
@@ -1,7 +1,8 @@
 (ns mongofinil.validation-helpers
-  (:require [clojure.set])
-  (:require [clojure.string])
-  (:use [mongofinil.helpers :only (ref?)]))
+  (:require [clojure.set]
+            [clojure.string]
+
+            [mongofinil.helpers :refer (ref?)]))
 
 (defmacro require-predicate [f & msg]
   `(fn [o#]

--- a/test/mongofinil/test_core.clj
+++ b/test/mongofinil/test_core.clj
@@ -1,10 +1,11 @@
 (ns mongofinil.test-core
   (:require [bond.james :as bond]
             [clj-time.core :as time]
+            [midje.sweet :refer (anything contains fact future-fact just throws)]
             [somnium.congomongo :as congo]
+
             [mongofinil.core :as core]
             [mongofinil.testing-utils :as utils])
-  (:use midje.sweet)
   (:import org.bson.types.ObjectId))
 
 (defn initializer []

--- a/test/mongofinil/test_core.clj
+++ b/test/mongofinil/test_core.clj
@@ -53,7 +53,7 @@
 
            ;; default
            {:name :dx :default 5}
-           {:name :dy :default (fn [b] 6)}
+           {:name :dy :default (fn [_] 6)}
            {:name :dz :default (fn [b] (-> b :x))}
 
            ;; ordered defaults
@@ -81,7 +81,7 @@
           :load {:post #'load-hook}
           :update {:post #'update-hook}}
 
-  :validations [(fn [row] (when false "failing"))]
+  :validations [(fn [_] nil)]
 
   :fn-middleware #'fn-middleware)
 
@@ -176,10 +176,10 @@
 
 
 (fact "apply-defaults works"
-  (core/apply-defaults [[:x 5] [:y (fn [v] 6)] [:z 10]] {:z 9} nil) => (just {:x 5 :y 6 :z 9}))
+  (core/apply-defaults [[:x 5] [:y (fn [_] 6)] [:z 10]] {:z 9} nil) => (just {:x 5 :y 6 :z 9}))
 
 (fact "apply-defaults works with only"
-  (core/apply-defaults [[:x 5] [:y (fn [v] 6)] [:z 10]] {:z 9} [:z]) => (just {:z 9}))
+  (core/apply-defaults [[:x 5] [:y (fn [_] 6)] [:z 10]] {:z 9} [:z]) => (just {:z 9}))
 
 
 (fact "default works on creation"

--- a/test/mongofinil/test_core_required.clj
+++ b/test/mongofinil/test_core_required.clj
@@ -1,7 +1,8 @@
 (ns mongofinil.test-core-required
-  (:use midje.sweet)
-  (:require [mongofinil.core :as core])
-  (:require [mongofinil.testing-utils :as utils]))
+  (:require [midje.sweet :refer (contains fact future-fact throws)]
+
+            [mongofinil.core :as core]
+            [mongofinil.testing-utils :as utils]))
 
 (utils/setup-test-db)
 (utils/setup-midje)

--- a/test/mongofinil/test_helpers.clj
+++ b/test/mongofinil/test_helpers.clj
@@ -1,5 +1,3 @@
-(ns mongofinil.test-helpers
-  (:use [midje.sweet])
-  (:require [somnium.congomongo :as congo]))
+(ns mongofinil.test-helpers)
 
 ;;; Not helpers for tests, test for helpers

--- a/test/mongofinil/test_hooks.clj
+++ b/test/mongofinil/test_hooks.clj
@@ -1,11 +1,9 @@
 (ns mongofinil.test-hooks
   (:require [bond.james :as bond]
-            [somnium.congomongo :as congo]
-            [mongofinil.core :as core]
-            [mongofinil.testing-utils :as utils])
-  (:use midje.sweet)
-  (:import org.bson.types.ObjectId))
+            [midje.sweet :refer (anything contains fact)]
 
+            [mongofinil.core :as core]
+            [mongofinil.testing-utils :as utils]))
 
 (utils/setup-test-db)
 (utils/setup-midje)

--- a/test/mongofinil/test_profiling.clj
+++ b/test/mongofinil/test_profiling.clj
@@ -1,9 +1,8 @@
 (ns mongofinil.test-profiling
-  (:require [somnium.congomongo :as congo]
+  (:require [midje.sweet :refer (fact)]
+
             [mongofinil.core :as core]
-            [mongofinil.testing-utils :as utils]
-            [clj-time.core :as time])
-  (:use midje.sweet))
+            [mongofinil.testing-utils :as utils]))
 
 (utils/setup-test-db)
 (utils/setup-midje)

--- a/test/mongofinil/test_refs.clj
+++ b/test/mongofinil/test_refs.clj
@@ -27,7 +27,7 @@
 
            ;; default
            {:name :dx :default 5}
-           {:name :dy :default (fn [b] 6)}
+           {:name :dy :default (fn [_] 6)}
            {:name :dz :default (fn [b] (-> b :x))}
 
            ;; ordered defaults
@@ -51,7 +51,7 @@
                    :post identity}
           :load {:post identity
                  :pre identity}}
-  :validations [(fn [row] (when false "failing"))])
+  :validations [(fn [_] nil)])
 
 (fact "row findable functions are created and work"
   (let [obj1 (create! {:x 1 :y 2 :z 3 :w 4})
@@ -123,10 +123,10 @@
 
 
 (fact "apply-defaults works"
-  (core/apply-defaults [[:x 5] [:y (fn [v] 6)] [:z 10]] {:z 9} nil) => (just {:x 5 :y 6 :z 9}))
+  (core/apply-defaults [[:x 5] [:y (fn [_] 6)] [:z 10]] {:z 9} nil) => (just {:x 5 :y 6 :z 9}))
 
 (fact "apply-defaults works with only"
-  (core/apply-defaults [[:x 5] [:y (fn [v] 6)] [:z 10]] {:z 9} [:z]) => (just {:z 9}))
+  (core/apply-defaults [[:x 5] [:y (fn [_] 6)] [:z 10]] {:z 9} [:z]) => (just {:z 9}))
 
 
 (fact "default works on creation"

--- a/test/mongofinil/test_refs.clj
+++ b/test/mongofinil/test_refs.clj
@@ -1,10 +1,10 @@
 (ns mongofinil.test-refs
-  (:use midje.sweet)
-  (:require [somnium.congomongo :as congo])
-  (:require [mongofinil.core :as core])
-  (:require [mongofinil.testing-utils :as utils])
-  (:use [mongofinil.helpers :only (ref?)])
-  (:import org.bson.types.ObjectId))
+  (:require [midje.sweet :refer (anything contains fact future-fact just throws)]
+            [somnium.congomongo :as congo]
+
+            [mongofinil.core :as core]
+            [mongofinil.helpers :refer (ref?)]
+            [mongofinil.testing-utils :as utils]))
 
 (defn initializer []
   (congo/add-index! :xs [:a])

--- a/test/mongofinil/testing_utils.clj
+++ b/test/mongofinil/testing_utils.clj
@@ -1,6 +1,6 @@
 (ns mongofinil.testing-utils
-  (:use midje.sweet)
-  (:require [somnium.congomongo :as congo]))
+  (:require [midje.sweet :refer (background)]
+            [somnium.congomongo :as congo]))
 
 (def test-db
   {:db :mongofinil_test_db


### PR DESCRIPTION
- Tidy up the requires and imports so that we only have what we need and we don't use `use` any more.
- Fix a completely broken `key-types` function that never would have worked.
- Reduce the number of unused bindings in the codebase.
- Ensure that docstrings come before the argument vector
- Remove unused code