### PR TITLE
Better profiling messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
 (defproject circleci/mongofinil "0.2.21"
   :description "A library for Mongoid-like models"
   :dependencies [[congomongo "1.1.0"]
-                 [clj-time "0.14.0"]]
+                 [clj-time "0.14.0"]
+                 [org.clojure/tools.logging "0.4.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure ~(or (System/getenv "CLOJURE_VERSION")
                                                             "1.8.0")]
                                   [circleci/bond "0.3.1"]

--- a/test/mongofinil/test_core.clj
+++ b/test/mongofinil/test_core.clj
@@ -449,19 +449,6 @@
     (-> load-hook bond/calls count) => 1
     (-> load-hook bond/calls first :args first) => (contains {:a []})))
 
-(fact "wrap-profile handles clock skew"
-  (core/wrap-profile println 1 "foo" "bar") => anything
-  (let [counter (atom 0)
-        before (time/minus (time/now) (time/seconds 2))
-        after (time/now)
-        stateful-time (fn []
-                        (swap! counter inc)
-                        (if (zero? (mod @counter 2))
-                          before
-                          after))]
-    (with-redefs [time/now stateful-time]
-      ((core/wrap-profile println 1 "foo" "bar")) => anything)))
-
 (fact "wrap-metrics-works"
   (let [metrics (atom [])
         log-metrics-fn (fn [ns name]

--- a/test/mongofinil/test_profiling.clj
+++ b/test/mongofinil/test_profiling.clj
@@ -1,5 +1,8 @@
 (ns mongofinil.test-profiling
-  (:require [midje.sweet :refer (fact)]
+  (:require [clojure.tools.logging :as log]
+
+            [bond.james :as bond]
+            [midje.sweet :refer (fact)]
 
             [mongofinil.core :as core]
             [mongofinil.testing-utils :as utils]))
@@ -10,7 +13,9 @@
 (core/defmodel :xs :fields [] :profile-reads 0 :profile-writes 5)
 
 (fact "slow operations warn"
-  (let [warning (with-out-str (create! {:val "abc" :x (into [] (range 50000))}))]
+  (let [warning (bond/with-spy [log/log*]
+                  (create! {:val "abc" :x (into [] (range 50000))})
+                  (->> log/log* bond/calls first :args last))]
     warning => #"slow query \(\d+ms\):"
     warning => #"mongofinil.test-profiling/create!"))
 


### PR DESCRIPTION
1. Time using System/nanoTime so that we don't have to care about clock skew.
2. Stop using println for logging.